### PR TITLE
Update Liberty Maven Plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.3.4</version>
+                <version>3.5.1</version>
             </plugin>
             <!-- end::libertyMavenPlugin[] -->
             <plugin>


### PR DESCRIPTION
Using the latest version of the Liberty Maven plugin will result in the Maven 3.8.2 and 3.8.3 warning message being displayed and block dev mode from running, indicating that users should upgrade to 3.8.4.